### PR TITLE
Fix #2: strip debugger statements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,15 +11,23 @@ export interface StripPlugin {
   transform: (code: string, id: string) => null | { code: string; map: null };
 }
 
-export function strip(options: StripOptions = {}): StripPlugin {
-  void options;
+function stripDebuggerStatements(code: string): string {
+  // Remove full lines that only contain a debugger statement.
+  return code.replace(/^[ \t]*debugger\s*;?[ \t]*\r?\n?/gm, "");
+}
 
+export function strip(options: StripOptions = {}): StripPlugin {
   return {
     name: "rolldown-plugin-strip",
     apply: "build",
     enforce: "pre",
     transform(code: string, _id: string) {
-      return { code, map: null };
+      if (!options.debugger) {
+        return { code, map: null };
+      }
+
+      const stripped = stripDebuggerStatements(code);
+      return { code: stripped, map: null };
     }
   };
 }

--- a/test/strip.test.ts
+++ b/test/strip.test.ts
@@ -13,7 +13,7 @@ describe("strip", () => {
   it("is currently a no-op transform", () => {
     const plugin = strip({
       functions: ["console.log"],
-      debugger: true,
+      debugger: false,
       labels: ["dev"]
     });
     const source = "console.log('hello'); debugger;";
@@ -21,6 +21,17 @@ describe("strip", () => {
 
     expect(transformed).toEqual({
       code: source,
+      map: null
+    });
+  });
+
+  it("removes debugger statements when enabled", () => {
+    const plugin = strip({ debugger: true });
+    const source = "const x = 1;\ndebugger;\nconst y = 2;\n";
+    const transformed = plugin.transform(source, "index.ts");
+
+    expect(transformed).toEqual({
+      code: "const x = 1;\nconst y = 2;\n",
       map: null
     });
   });


### PR DESCRIPTION
## Summary
- Added debugger stripping logic that removes standalone `debugger` statement lines when `strip({ debugger: true })` is enabled.
- Kept default behavior unchanged (`debugger` disabled remains a no-op for this part).
- Added focused tests for both disabled and enabled debugger behavior.

## Issues
- Fixes #2 — Strip debugger statements

## How to test
- `npm run check`
- `npm run build`

## Notes
- This is intentionally scoped to Issue #2 only; function-call stripping and label stripping remain for later issues.

---

## Learning notes

### Build-time code elimination as a boundary decision

**What it is**
Build-time elimination removes code before runtime executes, rather than guarding that code with runtime conditions. The plugin becomes a boundary where we decide what behavior can never ship to production artifacts.

**Where it appears in this PR**
`src/index.ts` in `transform()` applies `stripDebuggerStatements()` only when `options.debugger` is enabled.

**Why it was the right call here**
The alternative is leaving `debugger` statements in source and relying on runtime discipline (or minifier side effects) to avoid shipping them. Centralizing this in the plugin gives deterministic output and a testable contract for production builds. The tradeoff is reduced flexibility because removal is global for matched patterns, but for debugger statements that is usually desirable and predictable.

**If you want to go deeper**
Search: "build-time vs runtime policy enforcement" and "compiler passes for dead/debug code elimination".