### PR TITLE
Fix #3: strip configured call-expression statements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,17 +16,38 @@ function stripDebuggerStatements(code: string): string {
   return code.replace(/^[ \t]*debugger\s*;?[ \t]*\r?\n?/gm, "");
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripConfiguredCallExpressions(code: string, functions: string[]): string {
+  let output = code;
+
+  for (const fn of functions) {
+    const escaped = escapeRegExp(fn);
+    const pattern = new RegExp(`^[ \\t]*${escaped}\\s*\\([^\\n\\r;]*\\)\\s*;?[ \\t]*\\r?\\n?`, "gm");
+    output = output.replace(pattern, "");
+  }
+
+  return output;
+}
+
 export function strip(options: StripOptions = {}): StripPlugin {
   return {
     name: "rolldown-plugin-strip",
     apply: "build",
     enforce: "pre",
     transform(code: string, _id: string) {
-      if (!options.debugger) {
-        return { code, map: null };
+      let stripped = code;
+
+      if (options.debugger) {
+        stripped = stripDebuggerStatements(stripped);
       }
 
-      const stripped = stripDebuggerStatements(code);
+      if (options.functions?.length) {
+        stripped = stripConfiguredCallExpressions(stripped, options.functions);
+      }
+
       return { code: stripped, map: null };
     }
   };

--- a/test/strip.test.ts
+++ b/test/strip.test.ts
@@ -11,11 +11,7 @@ describe("strip", () => {
   });
 
   it("is currently a no-op transform", () => {
-    const plugin = strip({
-      functions: ["console.log"],
-      debugger: false,
-      labels: ["dev"]
-    });
+    const plugin = strip();
     const source = "console.log('hello'); debugger;";
     const transformed = plugin.transform(source, "index.ts");
 
@@ -32,6 +28,27 @@ describe("strip", () => {
 
     expect(transformed).toEqual({
       code: "const x = 1;\nconst y = 2;\n",
+      map: null
+    });
+  });
+
+  it("removes configured call expression statements", () => {
+    const plugin = strip({ functions: ["console.log", "logger.debug"] });
+    const source = [
+      "const keep = true;",
+      "console.log('remove me');",
+      "logger.debug('also remove');",
+      "logger.info('keep me');",
+      "const x = console.log('keep inline');"
+    ].join("\n");
+    const transformed = plugin.transform(source, "index.ts");
+
+    expect(transformed).toEqual({
+      code: [
+        "const keep = true;",
+        "logger.info('keep me');",
+        "const x = console.log('keep inline');"
+      ].join("\n"),
       map: null
     });
   });


### PR DESCRIPTION
## Summary
- Added configured function-call stripping for standalone expression statements via `functions` option matching.
- Supports dotted call targets like `console.log` and `logger.debug`.
- Preserves non-target calls and inline call expressions, keeping issue scope focused.

## Issues
- Fixes #3 — Strip configured function-call expression statements
- Refs #5 — chained-call safety remains for dedicated handling

## How to test
- `npm run check`
- `npm run build`

## Notes
- Current implementation is regex-based and intentionally scoped to line-based standalone calls; AST-based handling and chain safety are tracked in later issues.

---

## Learning notes

### Scope-first implementation to avoid cross-issue coupling

**What it is**
Scope-first implementation means shipping one clearly bounded behavior per issue, even when you can see adjacent improvements. It keeps review size small and prevents hidden coupling between features.

**Where it appears in this PR**
`src/index.ts` adds `stripConfiguredCallExpressions()` for standalone configured calls, while explicitly leaving chain-edge handling out of this change.

**Why it was the right call here**
The alternative was combining call stripping with chained-call safety and map-generation refactors in one PR. That would increase risk and make regressions harder to attribute. By separating concerns, this PR validates core matching semantics first, and later issues can focus on correctness edges with targeted tests.

**If you want to go deeper**
Search: "incremental architecture" and "small batch size in code review".