### PR TITLE
Fix #5: handle chained-call strip edge cases safely

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,10 +35,10 @@ function escapeRegExp(value: string): string {
 function findClosingParen(line: string, openParenIndex: number): number {
   let depth = 0;
   for (let i = openParenIndex; i < line.length; i += 1) {
-    const c = line[i];
-    if (c === "(") {
+    const currentChar = line[i];
+    if (currentChar === "(") {
       depth += 1;
-    } else if (c === ")") {
+    } else if (currentChar === ")") {
       depth -= 1;
       if (depth === 0) {
         return i;
@@ -48,13 +48,17 @@ function findClosingParen(line: string, openParenIndex: number): number {
   return -1;
 }
 
+/**
+ * Checks whether a line starts with a configured function call and whether
+ * that call is a whole removable statement.
+ */
 function analyzeCallExpressionLine(line: string, fn: string): { matched: boolean; safeRemove: boolean } {
-  const wsMatch = /^[ \t]*/.exec(line);
-  const wsLen = wsMatch ? wsMatch[0].length : 0;
-  if (!line.startsWith(fn, wsLen)) {
+  const leadingWhitespaceMatch = /^[ \t]*/.exec(line);
+  const leadingWhitespaceLength = leadingWhitespaceMatch ? leadingWhitespaceMatch[0].length : 0;
+  if (!line.startsWith(fn, leadingWhitespaceLength)) {
     return { matched: false, safeRemove: false };
   }
-  const openParen = wsLen + fn.length;
+  const openParen = leadingWhitespaceLength + fn.length;
   if (line[openParen] !== "(") {
     return { matched: false, safeRemove: false };
   }
@@ -69,6 +73,10 @@ function analyzeCallExpressionLine(line: string, fn: string): { matched: boolean
   return { matched: true, safeRemove: false };
 }
 
+/**
+ * Strips configured function calls when they are whole statements.
+ * For non-statement/chained matches, behavior is controlled by `chainedCalls`.
+ */
 function stripConfiguredCallExpressions(
   code: string,
   functions: string[],
@@ -78,17 +86,24 @@ function stripConfiguredCallExpressions(
   const lines = code.split(/\r?\n/);
   const out: string[] = [];
 
+  // Process each line independently so we can safely skip ambiguous chained cases.
   for (const line of lines) {
     let replaced = false;
+
+    // Try each configured function against the current line.
     for (const fn of functions) {
       const { matched, safeRemove } = analyzeCallExpressionLine(line, fn);
       if (!matched) {
         continue;
       }
+
+      // Whole-statement calls are safe to strip.
       if (safeRemove) {
         replaced = true;
         break;
       }
+
+      // Matched but not safe: enforce policy for chained/non-statement calls.
       if (chainedCalls === "error") {
         throw new Error(
           `rolldown-plugin-strip: refusing to strip chained or non-statement call "${fn}" in ${moduleId}: ${line.trim()}`
@@ -101,6 +116,8 @@ function stripConfiguredCallExpressions(
       }
       break;
     }
+
+    // Keep lines we did not strip.
     if (!replaced) {
       out.push(line);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
+export type ChainedCallsPolicy = "skip" | "warn" | "error";
+
 export interface StripOptions {
   functions?: string[];
   debugger?: boolean;
   labels?: string[];
+  /**
+   * When a configured call is not a whole statement (e.g. `fn().chain()`),
+   * stripping would break runtime. Controls behavior for those lines.
+   * @default "skip"
+   */
+  chainedCalls?: ChainedCallsPolicy;
 }
 
 export interface StripPlugin {
@@ -20,16 +28,85 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function stripConfiguredCallExpressions(code: string, functions: string[]): string {
-  let output = code;
+/**
+ * Returns index of the `)` that closes the `(` at `openParenIndex`, or -1.
+ * Does not parse strings; sufficient for typical strip targets on one line.
+ */
+function findClosingParen(line: string, openParenIndex: number): number {
+  let depth = 0;
+  for (let i = openParenIndex; i < line.length; i += 1) {
+    const c = line[i];
+    if (c === "(") {
+      depth += 1;
+    } else if (c === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
 
-  for (const fn of functions) {
-    const escaped = escapeRegExp(fn);
-    const pattern = new RegExp(`^[ \\t]*${escaped}\\s*\\([^\\n\\r;]*\\)\\s*;?[ \\t]*\\r?\\n?`, "gm");
-    output = output.replace(pattern, "");
+function analyzeCallExpressionLine(line: string, fn: string): { matched: boolean; safeRemove: boolean } {
+  const wsMatch = /^[ \t]*/.exec(line);
+  const wsLen = wsMatch ? wsMatch[0].length : 0;
+  if (!line.startsWith(fn, wsLen)) {
+    return { matched: false, safeRemove: false };
+  }
+  const openParen = wsLen + fn.length;
+  if (line[openParen] !== "(") {
+    return { matched: false, safeRemove: false };
+  }
+  const closeIdx = findClosingParen(line, openParen);
+  if (closeIdx === -1) {
+    return { matched: true, safeRemove: false };
+  }
+  const after = line.slice(closeIdx + 1);
+  if (/^[ \t]*(;[ \t]*)?$/.test(after)) {
+    return { matched: true, safeRemove: true };
+  }
+  return { matched: true, safeRemove: false };
+}
+
+function stripConfiguredCallExpressions(
+  code: string,
+  functions: string[],
+  chainedCalls: ChainedCallsPolicy,
+  moduleId: string
+): string {
+  const lines = code.split(/\r?\n/);
+  const out: string[] = [];
+
+  for (const line of lines) {
+    let replaced = false;
+    for (const fn of functions) {
+      const { matched, safeRemove } = analyzeCallExpressionLine(line, fn);
+      if (!matched) {
+        continue;
+      }
+      if (safeRemove) {
+        replaced = true;
+        break;
+      }
+      if (chainedCalls === "error") {
+        throw new Error(
+          `rolldown-plugin-strip: refusing to strip chained or non-statement call "${fn}" in ${moduleId}: ${line.trim()}`
+        );
+      }
+      if (chainedCalls === "warn") {
+        console.warn(
+          `[rolldown-plugin-strip] skipping strip of chained or non-statement call "${fn}" in ${moduleId}: ${line.trim()}`
+        );
+      }
+      break;
+    }
+    if (!replaced) {
+      out.push(line);
+    }
   }
 
-  return output;
+  return out.join("\n");
 }
 
 /**
@@ -104,7 +181,7 @@ export function strip(options: StripOptions = {}): StripPlugin {
     name: "rolldown-plugin-strip",
     apply: "build",
     enforce: "pre",
-    transform(code: string, _id: string) {
+    transform(code: string, id: string) {
       let stripped = code;
 
       if (options.debugger) {
@@ -112,7 +189,12 @@ export function strip(options: StripOptions = {}): StripPlugin {
       }
 
       if (options.functions?.length) {
-        stripped = stripConfiguredCallExpressions(stripped, options.functions);
+        stripped = stripConfiguredCallExpressions(
+          stripped,
+          options.functions,
+          options.chainedCalls ?? "skip",
+          id
+        );
       }
 
       if (options.labels?.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
+/**
+ * When a configured call matches a line but the line is not only that call
+ * (e.g. `fn().chain()`), stripping would break runtime. This policy controls
+ * that case. Default at runtime is `"skip"` when the option is omitted.
+ */
 export type ChainedCallsPolicy = "skip" | "warn" | "error";
 
 export interface StripOptions {
   functions?: string[];
   debugger?: boolean;
   labels?: string[];
-  /**
-   * When a configured call is not a whole statement (e.g. `fn().chain()`),
-   * stripping would break runtime. Controls behavior for those lines.
-   * @default "skip"
-   */
   chainedCalls?: ChainedCallsPolicy;
 }
 
@@ -53,21 +53,28 @@ function findClosingParen(line: string, openParenIndex: number): number {
  * that call is a whole removable statement.
  */
 function analyzeCallExpressionLine(line: string, fn: string): { matched: boolean; safeRemove: boolean } {
+  // Leading indentation only; the call must start immediately after it.
   const leadingWhitespaceMatch = /^[ \t]*/.exec(line);
   const leadingWhitespaceLength = leadingWhitespaceMatch ? leadingWhitespaceMatch[0].length : 0;
   if (!line.startsWith(fn, leadingWhitespaceLength)) {
     return { matched: false, safeRemove: false };
   }
-  const openParen = leadingWhitespaceLength + fn.length;
-  if (line[openParen] !== "(") {
+
+  // A call expression must begin with `fn(` for the configured name `fn`.
+  const openingParenIndex = leadingWhitespaceLength + fn.length;
+  if (line[openingParenIndex] !== "(") {
     return { matched: false, safeRemove: false };
   }
-  const closeIdx = findClosingParen(line, openParen);
-  if (closeIdx === -1) {
+
+  // Walk parentheses so nested calls inside arguments do not confuse the end.
+  const closingParenIndex = findClosingParen(line, openingParenIndex);
+  if (closingParenIndex === -1) {
     return { matched: true, safeRemove: false };
   }
-  const after = line.slice(closeIdx + 1);
-  if (/^[ \t]*(;[ \t]*)?$/.test(after)) {
+
+  // Safe removal only if nothing meaningful remains after the call (optional `;`).
+  const remainderAfterCall = line.slice(closingParenIndex + 1);
+  if (/^[ \t]*(;[ \t]*)?$/.test(remainderAfterCall)) {
     return { matched: true, safeRemove: true };
   }
   return { matched: true, safeRemove: false };

--- a/test/strip.test.ts
+++ b/test/strip.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { strip } from "../src/index.js";
 
 describe("strip", () => {
@@ -33,7 +33,7 @@ describe("strip", () => {
   });
 
   it("removes configured call expression statements", () => {
-    const plugin = strip({ functions: ["console.log", "logger.debug"] });
+    const plugin = strip({ functions: ["console.log", "logger.debug"], chainedCalls: "skip" });
     const source = [
       "const keep = true;",
       "console.log('remove me');",
@@ -51,6 +51,38 @@ describe("strip", () => {
       ].join("\n"),
       map: null
     });
+  });
+
+  it("skips chained calls by default so stripping does not break runtime", () => {
+    const plugin = strip({ functions: ["console.log"] });
+    const source = ["console.log('ok');", "console.log('x').then(() => {});", "console.log('tail');"].join("\n");
+    const transformed = plugin.transform(source, "chain.ts");
+
+    expect(transformed).toEqual({
+      code: "console.log('x').then(() => {});",
+      map: null
+    });
+  });
+
+  it("throws on chained calls when chainedCalls is error", () => {
+    const plugin = strip({ functions: ["console.log"], chainedCalls: "error" });
+    const source = "console.log('x').then(() => {});";
+
+    expect(() => plugin.transform(source, "bad.ts")).toThrow(/refusing to strip chained/);
+  });
+
+  it("warns on chained calls when chainedCalls is warn", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const plugin = strip({ functions: ["console.log"], chainedCalls: "warn" });
+      const source = "console.log('x').then(() => {});";
+      const transformed = plugin.transform(source, "warn.ts");
+
+      expect(transformed?.code).toBe(source);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("removes configured labeled blocks (MDN-style)", () => {


### PR DESCRIPTION
## Summary
- Replaced regex-only function stripping with a line-based pass that finds the matching closing `)` for the configured call.
- Removes a line only when the call is the whole statement (optional whitespace and trailing `;` after the call).
- Adds `chainedCalls` option: `skip` (default), `warn` (`console.warn`), or `error` (throws from `transform`) when a line matches a configured call but has trailing code after the call (chains like `.then`, or other expressions).

## Issues
- Fixes #5

## How to test
- `npm run check`
- `npm run build`

## Notes
- Line-based analysis matches prior single-line behavior; multi-line call statements are out of scope for this pass.
- Warn path uses `console.warn` today; wiring to Rolldown/Rollup `this.warn` can follow if we extend the transform signature.

---

## Learning notes

### Fail-safe default for destructive transforms

**What it is**
When a build transform can change runtime behavior, the default policy should be the least surprising: do nothing ambiguous rather than emit broken code.

**Where it appears in this PR**
`src/index.ts` — `chainedCalls` defaults to `skip`, so ambiguous lines are left unchanged unless the user opts into `warn` or `error`.

**Why it was the right call here**
The alternative default is aggressive stripping (e.g. turning `fn().chain` into invalid or throwing code). Default `skip` matches the sharp-edge story from `@rollup/plugin-strip` and keeps production builds safe until the user explicitly chooses stricter behavior.

**Optional mini snippet (when helpful)**

```ts
// Safe whole-statement strip:
console.log("x");

// Not stripped with default chainedCalls: "skip"
console.log("x").then(() => {});
```

**If you want to go deeper**
Search: "defensive defaults" and "parse vs replace for code transforms".