### PR TITLE
Fix #9: emit source maps for transformed output

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Outcomes for the chained/non-statement line:
 
 ## Notes
 
-- The plugin returns `map: null` in `transform` today (source-map emission is not implemented yet).
+- When the transform changes the module source, `transform` returns a **non-null** source map (VLQ v3) so debuggers and error stacks can map generated output back to the original file. Unchanged modules keep `map: null`.
+- When `functions` is enabled, line endings are normalized the same way as the stripper (`split(/\r?\n/).join("\n")`); if that step runs, the map is composed from the removal map and the newline-normalization map.
 - Call-expression matching is line-based and intentionally conservative to avoid unsafe removals.
 
 ## Local development and test

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,12 @@
       "name": "rolldown-plugin-strip",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "magic-string": "^0.30.21"
+      },
       "devDependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
         "@types/estree": "^1.0.8",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -456,12 +461,50 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1148,7 +1191,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,13 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@types/estree": "^1.0.8",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "@jridgewell/remapping": "^2.3.5",
+    "magic-string": "^0.30.21"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export interface StripOptions {
   chainedCalls?: ChainedCallsPolicy;
 }
 
+// Virtual filename linking the removal-stage map to the LF-normalization map in `remapping` (not a real path).
 const STRIP_INTERMEDIATE = "\0rolldown-plugin-strip/intermediate";
 
 export type StripTransformMap = ReturnType<MagicString["generateMap"]> | ReturnType<typeof remapping>;
@@ -297,15 +298,15 @@ function findDebuggerRemovalRanges(code: string): [number, number][] {
 function computeLineStarts(code: string, lines: string[]): number[] {
   const starts: number[] = new Array(lines.length);
   starts[0] = 0;
-  let pos = 0;
+  let offsetInOriginalFile = 0;
   for (let i = 0; i < lines.length - 1; i += 1) {
-    pos += lines[i].length;
-    if (pos < code.length && code.slice(pos, pos + 2) === "\r\n") {
-      pos += 2;
-    } else if (pos < code.length && (code[pos] === "\n" || code[pos] === "\r")) {
-      pos += 1;
+    offsetInOriginalFile += lines[i].length;
+    if (offsetInOriginalFile < code.length && code.slice(offsetInOriginalFile, offsetInOriginalFile + 2) === "\r\n") {
+      offsetInOriginalFile += 2;
+    } else if (offsetInOriginalFile < code.length && (code[offsetInOriginalFile] === "\n" || code[offsetInOriginalFile] === "\r")) {
+      offsetInOriginalFile += 1;
     }
-    starts[i + 1] = pos;
+    starts[i + 1] = offsetInOriginalFile;
   }
   return starts;
 }
@@ -396,15 +397,15 @@ function normalizeLineEndingsToLfLikeStrip(code: string): string {
   return code.split(/\r?\n/).join("\n");
 }
 
-function buildNormalizeMagicString(mid: string, normalized: string): MagicString {
-  const msNorm = new MagicString(mid);
-  for (let i = mid.length - 2; i >= 0; i -= 1) {
-    if (mid[i] === "\r" && mid[i + 1] === "\n") {
+function buildNormalizeMagicString(codeAfterRemovals: string, normalized: string): MagicString {
+  const msNorm = new MagicString(codeAfterRemovals);
+  for (let i = codeAfterRemovals.length - 2; i >= 0; i -= 1) {
+    if (codeAfterRemovals[i] === "\r" && codeAfterRemovals[i + 1] === "\n") {
       msNorm.overwrite(i, i + 2, "\n");
     }
   }
   if (msNorm.toString() !== normalized) {
-    msNorm.overwrite(0, mid.length, normalized);
+    msNorm.overwrite(0, codeAfterRemovals.length, normalized);
   }
   return msNorm;
 }
@@ -464,19 +465,20 @@ export function strip(options: StripOptions = {}): StripPlugin {
       const allRemovalRanges = mergeRanges([...dbgRanges, ...fnRangesOrig, ...labelRangesOrig]);
 
       const ms = new MagicString(code);
-      const sortedRemovals = [...allRemovalRanges].sort((a, b) => b[0] - a[0]);
-      for (const [start, end] of sortedRemovals) {
+      // Descending by range start: apply removals from later offsets first (batch delete convention; offsets stay in original-file space).
+      const sortedRemovalRangesDescending = [...allRemovalRanges].sort((a, b) => b[0] - a[0]);
+      for (const [start, end] of sortedRemovalRangesDescending) {
         ms.remove(start, end);
       }
 
-      const mid = ms.toString();
-      let finalCode = mid;
+      const codeAfterRemovals = ms.toString();
+      let finalCode = codeAfterRemovals;
       let map: StripTransformMap;
 
       if (options.functions?.length) {
-        const normalized = normalizeLineEndingsToLfLikeStrip(mid);
-        if (normalized !== mid) {
-          const msNorm = buildNormalizeMagicString(mid, normalized);
+        const normalized = normalizeLineEndingsToLfLikeStrip(codeAfterRemovals);
+        if (normalized !== codeAfterRemovals) {
+          const msNorm = buildNormalizeMagicString(codeAfterRemovals, normalized);
           const mapRemovals = JSON.parse(
             ms.generateMap({
               file: STRIP_INTERMEDIATE,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import remapping, { type SourceMapInput } from "@jridgewell/remapping";
+import MagicString from "magic-string";
+
 /**
  * When a configured call matches a line but the line is not only that call
  * (e.g. `fn().chain()`), stripping would break runtime. This policy controls
@@ -12,11 +15,15 @@ export interface StripOptions {
   chainedCalls?: ChainedCallsPolicy;
 }
 
+const STRIP_INTERMEDIATE = "\0rolldown-plugin-strip/intermediate";
+
+export type StripTransformMap = ReturnType<MagicString["generateMap"]> | ReturnType<typeof remapping>;
+
 export interface StripPlugin {
   name: "rolldown-plugin-strip";
   apply: "build";
   enforce: "pre";
-  transform: (code: string, id: string) => null | { code: string; map: null };
+  transform: (code: string, id: string) => null | { code: string; map: StripTransformMap | null };
 }
 
 function stripDebuggerStatements(code: string): string {
@@ -155,10 +162,8 @@ function findMatchingBrace(code: string, openBraceIndex: number): number {
   return -1;
 }
 
-/**
- * Removes statements prefixed with configured labels, including labeled blocks.
- */
-function stripConfiguredLabels(code: string, labels: string[]): string {
+function stripConfiguredLabelsSequential(code: string, labels: string[]): { code: string; orderedRemovals: [number, number][] } {
+  const orderedRemovals: [number, number][] = [];
   let output = code;
 
   for (const label of labels) {
@@ -187,6 +192,7 @@ function stripConfiguredLabels(code: string, labels: string[]): string {
         removeEnd += 1;
       }
 
+      orderedRemovals.push([matchStart, removeEnd]);
       output = output.slice(0, matchStart) + output.slice(removeEnd);
       blockPattern.lastIndex = matchStart;
       blockMatch = blockPattern.exec(output);
@@ -194,10 +200,227 @@ function stripConfiguredLabels(code: string, labels: string[]): string {
 
     // Remove single-line labeled statements such as `test: doThing();`.
     const statementPattern = new RegExp(`^[ \\t]*${escaped}[ \\t]*:[^\\n\\r]*\\r?\\n?`, "gm");
-    output = output.replace(statementPattern, "");
+    output = output.replace(statementPattern, (match, offset: number) => {
+      orderedRemovals.push([offset, offset + match.length]);
+      return "";
+    });
   }
 
-  return output;
+  return { code: output, orderedRemovals };
+}
+
+/**
+ * Removes statements prefixed with configured labels, including labeled blocks.
+ */
+function stripConfiguredLabels(code: string, labels: string[]): string {
+  return stripConfiguredLabelsSequential(code, labels).code;
+}
+
+function mergeRanges(ranges: [number, number][]): [number, number][] {
+  if (!ranges.length) {
+    return [];
+  }
+  const sorted = [...ranges].sort((a, b) => a[0] - b[0]);
+  const out: [number, number][] = [];
+  let [currentStart, currentEnd] = sorted[0];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const [start, end] = sorted[i];
+    if (start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, end);
+    } else {
+      out.push([currentStart, currentEnd]);
+      currentStart = start;
+      currentEnd = end;
+    }
+  }
+  out.push([currentStart, currentEnd]);
+  return out;
+}
+
+function afterLength(originalCode: string, removals: [number, number][]): number {
+  const merged = mergeRanges(removals);
+  const removed = merged.reduce((sum, [a, b]) => sum + (b - a), 0);
+  return originalCode.length - removed;
+}
+
+function afterToOriginalIndex(originalCode: string, mergedRemovals: [number, number][], afterPos: number): number {
+  const afterLen = afterLength(originalCode, mergedRemovals);
+  if (afterPos < 0 || afterPos > afterLen) {
+    throw new Error(`rolldown-plugin-strip: internal mapping error (afterPos ${afterPos}, len ${afterLen})`);
+  }
+  if (afterPos === afterLen) {
+    return originalCode.length;
+  }
+
+  let orig = 0;
+  let after = 0;
+  let ri = 0;
+
+  while (orig < originalCode.length) {
+    while (ri < mergedRemovals.length && orig >= mergedRemovals[ri][1]) {
+      ri += 1;
+    }
+    if (ri < mergedRemovals.length && orig >= mergedRemovals[ri][0] && orig < mergedRemovals[ri][1]) {
+      orig = mergedRemovals[ri][1];
+      continue;
+    }
+    if (after === afterPos) {
+      return orig;
+    }
+    orig += 1;
+    after += 1;
+  }
+
+  return originalCode.length;
+}
+
+function mapAfterRangeToOriginal(
+  originalCode: string,
+  removalsInOriginal: [number, number][],
+  rangeAfter: [number, number]
+): [number, number] {
+  const merged = mergeRanges(removalsInOriginal);
+  const [a, b] = rangeAfter;
+  return [afterToOriginalIndex(originalCode, merged, a), afterToOriginalIndex(originalCode, merged, b)];
+}
+
+function findDebuggerRemovalRanges(code: string): [number, number][] {
+  const re = /^[ \t]*debugger\s*;?[ \t]*\r?\n?/gm;
+  const out: [number, number][] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(code))) {
+    out.push([match.index, match.index + match[0].length]);
+  }
+  return out;
+}
+
+function computeLineStarts(code: string, lines: string[]): number[] {
+  const starts: number[] = new Array(lines.length);
+  starts[0] = 0;
+  let pos = 0;
+  for (let i = 0; i < lines.length - 1; i += 1) {
+    pos += lines[i].length;
+    if (pos < code.length && code.slice(pos, pos + 2) === "\r\n") {
+      pos += 2;
+    } else if (pos < code.length && (code[pos] === "\n" || code[pos] === "\r")) {
+      pos += 1;
+    }
+    starts[i + 1] = pos;
+  }
+  return starts;
+}
+
+function lineRemovalRange(
+  lineStarts: number[],
+  lines: string[],
+  lineIndex: number,
+  lineCount: number,
+  codeLength: number
+): [number, number] {
+  const start = lineStarts[lineIndex];
+  if (lineIndex < lineCount - 1) {
+    return [start, lineStarts[lineIndex + 1]];
+  }
+  // Last line: include the newline (or CRLF) before it so we do not leave a trailing separator
+  // after the previous kept line (matches `lines.filter(...).join("\n")` semantics).
+  if (lineIndex > 0) {
+    const afterPrevious = lineStarts[lineIndex - 1] + lines[lineIndex - 1].length;
+    return [afterPrevious, codeLength];
+  }
+  return [start, codeLength];
+}
+
+function findFunctionRemovalRangesInCode(
+  code: string,
+  functions: string[],
+  chainedCalls: ChainedCallsPolicy,
+  moduleId: string
+): [number, number][] {
+  const ranges: [number, number][] = [];
+  const lines = code.split(/\r?\n/);
+  const lineStarts = computeLineStarts(code, lines);
+  const lineCount = lines.length;
+
+  for (let lineIndex = 0; lineIndex < lineCount; lineIndex += 1) {
+    const line = lines[lineIndex];
+    let replaced = false;
+
+    for (const fn of functions) {
+      const { matched, safeRemove } = analyzeCallExpressionLine(line, fn);
+      if (!matched) {
+        continue;
+      }
+      if (safeRemove) {
+        replaced = true;
+        break;
+      }
+      if (chainedCalls === "error") {
+        throw new Error(
+          `rolldown-plugin-strip: refusing to strip chained or non-statement call "${fn}" in ${moduleId}: ${line.trim()}`
+        );
+      }
+      if (chainedCalls === "warn") {
+        console.warn(
+          `[rolldown-plugin-strip] skipping strip of chained or non-statement call "${fn}" in ${moduleId}: ${line.trim()}`
+        );
+      }
+      break;
+    }
+
+    if (replaced) {
+      ranges.push(lineRemovalRange(lineStarts, lines, lineIndex, lineCount, code.length));
+    }
+  }
+
+  return ranges;
+}
+
+function expandThroughRemoval(pos: number, removal: [number, number]): number {
+  if (pos < removal[0]) {
+    return pos;
+  }
+  return pos + (removal[1] - removal[0]);
+}
+
+function expandRangeThroughPriorRemovals(range: [number, number], priorRemovalsInOrder: [number, number][]): [number, number] {
+  let [start, end] = range;
+  for (let i = priorRemovalsInOrder.length - 1; i >= 0; i -= 1) {
+    const removal = priorRemovalsInOrder[i];
+    start = expandThroughRemoval(start, removal);
+    end = expandThroughRemoval(end, removal);
+  }
+  return [start, end];
+}
+
+function normalizeLineEndingsToLfLikeStrip(code: string): string {
+  return code.split(/\r?\n/).join("\n");
+}
+
+function buildNormalizeMagicString(mid: string, normalized: string): MagicString {
+  const msNorm = new MagicString(mid);
+  for (let i = mid.length - 2; i >= 0; i -= 1) {
+    if (mid[i] === "\r" && mid[i + 1] === "\n") {
+      msNorm.overwrite(i, i + 2, "\n");
+    }
+  }
+  if (msNorm.toString() !== normalized) {
+    msNorm.overwrite(0, mid.length, normalized);
+  }
+  return msNorm;
+}
+
+function runStripPipeline(code: string, options: StripOptions, moduleId: string): string {
+  let stripped = code;
+  if (options.debugger) {
+    stripped = stripDebuggerStatements(stripped);
+  }
+  if (options.functions?.length) {
+    stripped = stripConfiguredCallExpressions(stripped, options.functions, options.chainedCalls ?? "skip", moduleId);
+  }
+  if (options.labels?.length) {
+    stripped = stripConfiguredLabels(stripped, options.labels);
+  }
+  return stripped;
 }
 
 export function strip(options: StripOptions = {}): StripPlugin {
@@ -206,26 +429,94 @@ export function strip(options: StripOptions = {}): StripPlugin {
     apply: "build",
     enforce: "pre",
     transform(code: string, id: string) {
-      let stripped = code;
-
-      if (options.debugger) {
-        stripped = stripDebuggerStatements(stripped);
+      const expected = runStripPipeline(code, options, id);
+      if (expected === code) {
+        return { code, map: null };
       }
+
+      const dbgRanges = options.debugger ? findDebuggerRemovalRanges(code) : [];
+      const dbgMerged = mergeRanges(dbgRanges);
+
+      const d1 = options.debugger ? stripDebuggerStatements(code) : code;
+
+      const fnRangesD1 = options.functions?.length
+        ? findFunctionRemovalRangesInCode(d1, options.functions, options.chainedCalls ?? "skip", id)
+        : [];
+      const fnMergedD1 = mergeRanges(fnRangesD1);
+
+      const d2 = options.functions?.length
+        ? stripConfiguredCallExpressions(d1, options.functions, options.chainedCalls ?? "skip", id)
+        : d1;
+
+      const { orderedRemovals: labelOrderedInD2 } = options.labels?.length
+        ? stripConfiguredLabelsSequential(d2, options.labels)
+        : { orderedRemovals: [] as [number, number][] };
+
+      const labelRangesD2Root = labelOrderedInD2.map((removal, index) =>
+        expandRangeThroughPriorRemovals(removal, labelOrderedInD2.slice(0, index))
+      );
+
+      const fnRangesOrig = fnRangesD1.map((range) => mapAfterRangeToOriginal(code, dbgMerged, range));
+      const labelRangesOrig = labelRangesD2Root.map((range) =>
+        mapAfterRangeToOriginal(code, dbgMerged, mapAfterRangeToOriginal(d1, fnMergedD1, range))
+      );
+
+      const allRemovalRanges = mergeRanges([...dbgRanges, ...fnRangesOrig, ...labelRangesOrig]);
+
+      const ms = new MagicString(code);
+      const sortedRemovals = [...allRemovalRanges].sort((a, b) => b[0] - a[0]);
+      for (const [start, end] of sortedRemovals) {
+        ms.remove(start, end);
+      }
+
+      const mid = ms.toString();
+      let finalCode = mid;
+      let map: StripTransformMap;
 
       if (options.functions?.length) {
-        stripped = stripConfiguredCallExpressions(
-          stripped,
-          options.functions,
-          options.chainedCalls ?? "skip",
-          id
-        );
+        const normalized = normalizeLineEndingsToLfLikeStrip(mid);
+        if (normalized !== mid) {
+          const msNorm = buildNormalizeMagicString(mid, normalized);
+          const mapRemovals = JSON.parse(
+            ms.generateMap({
+              file: STRIP_INTERMEDIATE,
+              source: id,
+              hires: true,
+              includeContent: false
+            }).toString()
+          ) as SourceMapInput;
+          const mapNormalize = JSON.parse(
+            msNorm.generateMap({
+              file: id,
+              source: STRIP_INTERMEDIATE,
+              hires: true,
+              includeContent: false
+            }).toString()
+          ) as SourceMapInput;
+          map = remapping([mapNormalize, mapRemovals], () => null);
+          finalCode = normalized;
+        } else {
+          map = ms.generateMap({
+            file: id,
+            source: id,
+            hires: true,
+            includeContent: false
+          });
+        }
+      } else {
+        map = ms.generateMap({
+          file: id,
+          source: id,
+          hires: true,
+          includeContent: false
+        });
       }
 
-      if (options.labels?.length) {
-        stripped = stripConfiguredLabels(stripped, options.labels);
+      if (finalCode !== expected) {
+        throw new Error("rolldown-plugin-strip: internal error — source map pipeline mismatch");
       }
 
-      return { code: stripped, map: null };
+      return { code: finalCode, map };
     }
   };
 }

--- a/test/strip.test.ts
+++ b/test/strip.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
-import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
+import { eachMapping, originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
 import { strip } from "../src/index.js";
 
 function parseSourceMapJson(map: { toString(): string } | null): Record<string, unknown> {
   expect(map).not.toBeNull();
   return JSON.parse(map!.toString()) as Record<string, unknown>;
+}
+
+/** Assert the map is not empty VLQ only — it actually contains traceable segments. */
+function expectSourceMapHasTraceableSegments(raw: Record<string, unknown>) {
+  const map = new TraceMap(raw as ConstructorParameters<typeof TraceMap>[0]);
+  let segmentCount = 0;
+  eachMapping(map, () => {
+    segmentCount += 1;
+  });
+  expect(segmentCount).toBeGreaterThan(0);
 }
 
 describe("strip", () => {
@@ -37,7 +47,7 @@ describe("strip", () => {
     expect(raw.version).toBe(3);
     expect(raw.sources).toEqual(["index.ts"]);
     expect(typeof raw.mappings).toBe("string");
-    expect((raw.mappings as string).length).toBeGreaterThan(0);
+    expectSourceMapHasTraceableSegments(raw);
   });
 
   it("maps generated lines back to the original source after stripping debugger", () => {
@@ -66,7 +76,7 @@ describe("strip", () => {
     );
     const raw = parseSourceMapJson(transformed!.map as { toString(): string });
     expect(raw.version).toBe(3);
-    expect((raw.mappings as string).length).toBeGreaterThan(0);
+    expectSourceMapHasTraceableSegments(raw);
   });
 
   it("skips chained calls by default so stripping does not break runtime", () => {
@@ -77,7 +87,7 @@ describe("strip", () => {
     expect(transformed?.code).toBe("console.log('x').then(() => {});");
     const raw = parseSourceMapJson(transformed!.map as { toString(): string });
     expect(raw.sources).toEqual(["chain.ts"]);
-    expect((raw.mappings as string).length).toBeGreaterThan(0);
+    expectSourceMapHasTraceableSegments(raw);
   });
 
   it("throws on chained calls when chainedCalls is error", () => {
@@ -117,7 +127,7 @@ describe("strip", () => {
 
     expect(transformed?.code).toBe(["console.log('before');", "console.log('after');"].join("\n"));
     const raw = parseSourceMapJson(transformed!.map as { toString(): string });
-    expect((raw.mappings as string).length).toBeGreaterThan(0);
+    expectSourceMapHasTraceableSegments(raw);
   });
 
   it("removes configured non-block labeled statements (MDN-style)", () => {
@@ -135,6 +145,6 @@ describe("strip", () => {
 
     expect(transformed?.code).toBe(["let x = 0;", "let z = 0;", "console.log('kept');"].join("\n"));
     const raw = parseSourceMapJson(transformed!.map as { toString(): string });
-    expect((raw.mappings as string).length).toBeGreaterThan(0);
+    expectSourceMapHasTraceableSegments(raw);
   });
 });

--- a/test/strip.test.ts
+++ b/test/strip.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
 import { strip } from "../src/index.js";
+
+function parseSourceMapJson(map: { toString(): string } | null): Record<string, unknown> {
+  expect(map).not.toBeNull();
+  return JSON.parse(map!.toString()) as Record<string, unknown>;
+}
 
 describe("strip", () => {
   it("returns a plugin with stable shape", () => {
@@ -10,7 +16,7 @@ describe("strip", () => {
     expect(plugin.enforce).toBe("pre");
   });
 
-  it("is currently a no-op transform", () => {
+  it("is a no-op transform when nothing is configured to strip", () => {
     const plugin = strip();
     const source = "console.log('hello'); debugger;";
     const transformed = plugin.transform(source, "index.ts");
@@ -26,10 +32,22 @@ describe("strip", () => {
     const source = "const x = 1;\ndebugger;\nconst y = 2;\n";
     const transformed = plugin.transform(source, "index.ts");
 
-    expect(transformed).toEqual({
-      code: "const x = 1;\nconst y = 2;\n",
-      map: null
-    });
+    expect(transformed?.code).toBe("const x = 1;\nconst y = 2;\n");
+    const raw = parseSourceMapJson(transformed!.map as { toString(): string });
+    expect(raw.version).toBe(3);
+    expect(raw.sources).toEqual(["index.ts"]);
+    expect(typeof raw.mappings).toBe("string");
+    expect((raw.mappings as string).length).toBeGreaterThan(0);
+  });
+
+  it("maps generated lines back to the original source after stripping debugger", () => {
+    const plugin = strip({ debugger: true });
+    const source = "const x = 1;\ndebugger;\nconst y = 2;\n";
+    const transformed = plugin.transform(source, "app.ts")!;
+    const map = new TraceMap(JSON.parse(transformed.map!.toString()));
+    const pos = originalPositionFor(map, { line: 2, column: 0 });
+    expect("line" in pos && pos.line).toBe(3);
+    expect("source" in pos && pos.source).toBe("app.ts");
   });
 
   it("removes configured call expression statements", () => {
@@ -43,14 +61,12 @@ describe("strip", () => {
     ].join("\n");
     const transformed = plugin.transform(source, "index.ts");
 
-    expect(transformed).toEqual({
-      code: [
-        "const keep = true;",
-        "logger.info('keep me');",
-        "const x = console.log('keep inline');"
-      ].join("\n"),
-      map: null
-    });
+    expect(transformed?.code).toBe(
+      ["const keep = true;", "logger.info('keep me');", "const x = console.log('keep inline');"].join("\n")
+    );
+    const raw = parseSourceMapJson(transformed!.map as { toString(): string });
+    expect(raw.version).toBe(3);
+    expect((raw.mappings as string).length).toBeGreaterThan(0);
   });
 
   it("skips chained calls by default so stripping does not break runtime", () => {
@@ -58,10 +74,10 @@ describe("strip", () => {
     const source = ["console.log('ok');", "console.log('x').then(() => {});", "console.log('tail');"].join("\n");
     const transformed = plugin.transform(source, "chain.ts");
 
-    expect(transformed).toEqual({
-      code: "console.log('x').then(() => {});",
-      map: null
-    });
+    expect(transformed?.code).toBe("console.log('x').then(() => {});");
+    const raw = parseSourceMapJson(transformed!.map as { toString(): string });
+    expect(raw.sources).toEqual(["chain.ts"]);
+    expect((raw.mappings as string).length).toBeGreaterThan(0);
   });
 
   it("throws on chained calls when chainedCalls is error", () => {
@@ -79,6 +95,7 @@ describe("strip", () => {
       const transformed = plugin.transform(source, "warn.ts");
 
       expect(transformed?.code).toBe(source);
+      expect(transformed?.map).toBeNull();
       expect(warn).toHaveBeenCalled();
     } finally {
       warn.mockRestore();
@@ -98,10 +115,9 @@ describe("strip", () => {
     ].join("\n");
     const transformed = plugin.transform(source, "index.ts");
 
-    expect(transformed).toEqual({
-      code: ["console.log('before');", "console.log('after');"].join("\n"),
-      map: null
-    });
+    expect(transformed?.code).toBe(["console.log('before');", "console.log('after');"].join("\n"));
+    const raw = parseSourceMapJson(transformed!.map as { toString(): string });
+    expect((raw.mappings as string).length).toBeGreaterThan(0);
   });
 
   it("removes configured non-block labeled statements (MDN-style)", () => {
@@ -117,9 +133,8 @@ describe("strip", () => {
     ].join("\n");
     const transformed = plugin.transform(source, "index.ts");
 
-    expect(transformed).toEqual({
-      code: ["let x = 0;", "let z = 0;", "console.log('kept');"].join("\n"),
-      map: null
-    });
+    expect(transformed?.code).toBe(["let x = 0;", "let z = 0;", "console.log('kept');"].join("\n"));
+    const raw = parseSourceMapJson(transformed!.map as { toString(): string });
+    expect((raw.mappings as string).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- Emit valid v3 source maps whenever `transform` changes module source, using `magic-string` removals keyed by original indices.
- Compose maps with `@jridgewell/remapping` when the `functions` pass also normalizes line endings (`split(/\r?\n/).join("\n")`).
- Fix whole-line removal ranges for the last line so multi-line call stripping matches existing `join("\n")` output (no stray newline after the sole kept line).
- Document map behavior in the README and extend tests to assert non-empty mappings plus one `originalPositionFor` trace.

## Issues
- Fixes #9

## How to test
- npm run check
- npm run build

## Notes
- Runtime deps added: `magic-string`, `@jridgewell/remapping` (map composition only when LF normalization runs).
- Dev dep added: `@jridgewell/trace-mapping` (tests only).
- An internal guard throws if the map pipeline ever diverges from the string pipeline; that indicates a bug in range bookkeeping rather than user input.

---

## Learning notes
### Source map composition across sequential transforms

**What it is**
When two transforms run in sequence (here: delete ranges, then normalize newlines), each can emit its own map. A **composed** map traces generated positions through both steps back to the original file.

**Where it appears in this PR**
`src/index.ts` — after `magic-string` removals, optional LF normalization uses a second `MagicString` on the intermediate string; `remapping([normalizeMap, removalMap], () => null)` folds those maps so consumers only see one map rooted at the Rolldown module id.

**Why it was the right call here**
Returning only the first-stage map would mis-attribute columns whenever `\r\n` collapses to `\n`. Composing keeps the contract “map matches emitted code” without teaching the removal pass about newline normalization edge cases.

**If you want to go deeper**
`@jridgewell/remapping` README — “Multiple transformations of a file” (array order: most recent map first).