### PR TITLE
chore: npm pre-publish readiness (license, metadata, prepublishOnly)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sam-parsons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -12,15 +12,24 @@
     "build": "tsc -p tsconfig.build.json",
     "check": "npm run lint && npm run test",
     "lint": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepublishOnly": "npm run check && npm run build"
   },
   "keywords": [
     "rolldown",
     "plugin",
     "strip"
   ],
-  "author": "",
+  "author": "sam-parsons",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sam-parsons/rolldown-plugin-strip.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sam-parsons/rolldown-plugin-strip/issues"
+  },
+  "homepage": "https://github.com/sam-parsons/rolldown-plugin-strip#readme",
   "devDependencies": {
     "@jridgewell/trace-mapping": "^0.3.31",
     "@types/estree": "^1.0.8",


### PR DESCRIPTION
Implements the [pre-publish checklist](https://github.com/sam-parsons/rolldown-plugin-strip/issues/15).

### Changes

- **`prepublishOnly`**: runs `npm run check && npm run build` so publishes never ship without tests passing and a fresh `dist/`.
- **`LICENSE`**: MIT text at the repo root (copyright holder `sam-parsons`, year 2026).
- **`package.json` metadata**: `author`, `repository`, `bugs`, and `homepage` pointing at this GitHub repo.

### Verification

`npm publish --dry-run` includes `LICENSE`, `README.md`, `package.json`, and `dist/*` as expected.

Closes #15.